### PR TITLE
feat: refactor token generation to be based on the account id.

### DIFF
--- a/src/main/java/GymApp/controller/OwnerAccountManagerController.java
+++ b/src/main/java/GymApp/controller/OwnerAccountManagerController.java
@@ -126,9 +126,9 @@ public class OwnerAccountManagerController {
     // Delete owner account (an owner can delete his own account.)
     @DeleteMapping("/owner-account-manager")
     @PreAuthorize("hasAuthority('SCOPE_OWNER')")
-    public ResponseEntity deleteOwnerAccount(Authentication authentication){
+    public ResponseEntity deleteOwnerAccount(Authentication authentication) {
         // extract email / phone number from the authentication object.
-        String name  = authentication.getName();
+        String name = authentication.getName();
 
         ownerService.deleteByAccount_EmailOrAccount_phoneNumber(name, name);
 

--- a/src/main/java/GymApp/entity/Account.java
+++ b/src/main/java/GymApp/entity/Account.java
@@ -12,7 +12,7 @@ public class Account {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
-    private int id;
+    private long id;
     @Column(name = "first_name", nullable = false)
     private String firstName;
     @Column(name = "second_name" , nullable = false)
@@ -45,11 +45,11 @@ public class Account {
         this.updatedAt = updatedAt;
     }
 
-    public int getId() {
+    public long getId() {
         return id;
     }
 
-    public void setId(int id) {
+    public void setId(long id) {
         this.id = id;
     }
 

--- a/src/main/java/GymApp/security/authenticationProvider/ClientAuthenticationProviderService.java
+++ b/src/main/java/GymApp/security/authenticationProvider/ClientAuthenticationProviderService.java
@@ -1,6 +1,7 @@
 package GymApp.security.authenticationProvider;
 
 
+import GymApp.security.userDetails.ClientDetails;
 import GymApp.security.userDetailsService.JpaClientDetailsService;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,7 +12,6 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -32,16 +32,15 @@ public class ClientAuthenticationProviderService implements AuthenticationProvid
         String emailOrPhoneNumber = authentication.getName();
         String password = authentication.getCredentials().toString();
 
-        UserDetails userDetails =  clientDetailsService.loadUserByUsername(emailOrPhoneNumber);
+        ClientDetails clientDetails =  clientDetailsService.loadUserByUsername(emailOrPhoneNumber);
 
-        return checkPassword(userDetails, password, bCryptPasswordEncoder);
-
-
+        return checkPassword(clientDetails, password, bCryptPasswordEncoder);
     }
-    private Authentication checkPassword(UserDetails userDetails, String rawPassword, PasswordEncoder encoder) {
+    private Authentication checkPassword(ClientDetails clientDetails, String rawPassword, PasswordEncoder encoder) {
 
-        if(encoder.matches(rawPassword, userDetails.getPassword())){
-            return new UsernamePasswordAuthenticationToken(userDetails.getUsername(), userDetails.getPassword(), userDetails.getAuthorities());
+        if(encoder.matches(rawPassword, clientDetails.getPassword())){
+            return new UsernamePasswordAuthenticationToken(clientDetails.getAccountId(), clientDetails.getPassword(),
+                    clientDetails.getAuthorities());
         }
         else{
             throw new BadCredentialsException("Bad Credentials");

--- a/src/main/java/GymApp/security/authenticationProvider/CoachAuthenticationProviderService.java
+++ b/src/main/java/GymApp/security/authenticationProvider/CoachAuthenticationProviderService.java
@@ -1,6 +1,7 @@
 package GymApp.security.authenticationProvider;
 
 
+import GymApp.security.userDetails.CoachDetails;
 import GymApp.security.userDetailsService.JpaCoachDetailsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
@@ -31,16 +32,17 @@ public class CoachAuthenticationProviderService implements AuthenticationProvide
         String emailOrPhoneNumber = authentication.getName();
         String password = authentication.getCredentials().toString();
 
-        UserDetails userDetails =  coachDetailsService.loadUserByUsername(emailOrPhoneNumber);
+        CoachDetails coachDetails =  coachDetailsService.loadUserByUsername(emailOrPhoneNumber);
 
-        return checkPassword(userDetails, password, bCryptPasswordEncoder);
+        return checkPassword(coachDetails, password, bCryptPasswordEncoder);
 
 
     }
-    private Authentication checkPassword(UserDetails userDetails, String rawPassword, PasswordEncoder encoder) {
+    private Authentication checkPassword(CoachDetails coachDetails, String rawPassword, PasswordEncoder encoder) {
 
-        if(encoder.matches(rawPassword, userDetails.getPassword())){
-            return new UsernamePasswordAuthenticationToken(userDetails.getUsername(), userDetails.getPassword(), userDetails.getAuthorities());
+        if(encoder.matches(rawPassword, coachDetails.getPassword())){
+            return new UsernamePasswordAuthenticationToken(coachDetails.getAccountId(), coachDetails.getPassword(),
+                    coachDetails.getAuthorities());
         }
         else{
             throw new BadCredentialsException("Bad Credentials");

--- a/src/main/java/GymApp/security/authenticationProvider/OwnerAuthenticationProviderService.java
+++ b/src/main/java/GymApp/security/authenticationProvider/OwnerAuthenticationProviderService.java
@@ -1,6 +1,7 @@
 package GymApp.security.authenticationProvider;
 
 
+import GymApp.security.userDetails.OwnerDetails;
 import GymApp.security.userDetailsService.JpaOwnerDetailsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
@@ -30,17 +31,17 @@ public class OwnerAuthenticationProviderService  implements AuthenticationProvid
         String emailOrPhoneNumber = authentication.getName();
         String password = authentication.getCredentials().toString();
 
-        UserDetails userDetails =  ownerDetailsService.loadUserByUsername(emailOrPhoneNumber);
+        OwnerDetails ownerDetails =  ownerDetailsService.loadUserByUsername(emailOrPhoneNumber);
 
-        return checkPassword(userDetails, password, bCryptPasswordEncoder);
+        return checkPassword(ownerDetails, password, bCryptPasswordEncoder);
 
 
     }
-    private Authentication checkPassword(UserDetails userDetails, String rawPassword, PasswordEncoder encoder) {
+    private Authentication checkPassword(OwnerDetails ownerDetails, String rawPassword, PasswordEncoder encoder) {
 
-        if(encoder.matches(rawPassword, userDetails.getPassword())){
-            return new UsernamePasswordAuthenticationToken(userDetails.getUsername(), userDetails.getPassword(),
-                    userDetails.getAuthorities());
+        if(encoder.matches(rawPassword, ownerDetails.getPassword())){
+            return new UsernamePasswordAuthenticationToken(ownerDetails.getAccountId(), ownerDetails.getPassword(),
+                    ownerDetails.getAuthorities());
         }
         else{
             throw new BadCredentialsException("Bad Credentials");

--- a/src/main/java/GymApp/security/userDetails/ClientDetails.java
+++ b/src/main/java/GymApp/security/userDetails/ClientDetails.java
@@ -52,9 +52,11 @@ public class ClientDetails implements CustomUserDetails {
         return false;
     }
 
-
     @Override
     public AccountType getAccountType(String accountType) {
         return AccountType.CLIENT;
+    }
+    public long getAccountId(){
+        return client.getAccount().getId();
     }
 }

--- a/src/main/java/GymApp/security/userDetails/CoachDetails.java
+++ b/src/main/java/GymApp/security/userDetails/CoachDetails.java
@@ -55,4 +55,7 @@ public class CoachDetails implements CustomUserDetails {
     public AccountType getAccountType(String accountType) {
         return AccountType.COACH;
     }
+    public long getAccountId(){
+        return coach.getAccount().getId();
+    }
 }

--- a/src/main/java/GymApp/security/userDetails/OwnerDetails.java
+++ b/src/main/java/GymApp/security/userDetails/OwnerDetails.java
@@ -56,4 +56,7 @@ public class OwnerDetails implements CustomUserDetails {
     public AccountType getAccountType(String accountType) {
         return AccountType.OWNER;
     }
+    public long getAccountId(){
+        return owner.getAccount().getId();
+    }
 }

--- a/src/main/java/GymApp/security/userDetailsService/JpaCoachDetailsService.java
+++ b/src/main/java/GymApp/security/userDetailsService/JpaCoachDetailsService.java
@@ -24,7 +24,7 @@ public class JpaCoachDetailsService implements UserDetailsService {
     private CoachService coachService;
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    public CoachDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         Supplier<UsernameNotFoundException> s =
                 () -> new UsernameNotFoundException("Problem during authentication!");
         Account account = accountService.findByEmailOrPhoneNumber(username, username).orElseThrow(s);

--- a/src/main/java/GymApp/security/userDetailsService/JpaOwnerDetailsService.java
+++ b/src/main/java/GymApp/security/userDetailsService/JpaOwnerDetailsService.java
@@ -28,7 +28,7 @@ public class JpaOwnerDetailsService implements UserDetailsService {
 
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    public OwnerDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         Supplier<UsernameNotFoundException> s =
                 () -> new UsernameNotFoundException("Problem during authentication!");
         Account account = accountService.findByEmailOrPhoneNumber(username, username).orElseThrow(s);

--- a/src/main/java/GymApp/service/TokenService.java
+++ b/src/main/java/GymApp/service/TokenService.java
@@ -25,14 +25,14 @@ public class TokenService {
         this.accountService = accountService;
     }
 
-    public String generateToken(String name, AccountType accountType) {
+    public String generateToken(String identifier, AccountType accountType) {
         Instant now = Instant.now();
         String scope = accountType.toString();
         JwtClaimsSet claims = JwtClaimsSet.builder()
                 .issuer("self")
                 .issuedAt(now)
                 .expiresAt(now.plus(1, ChronoUnit.HOURS))
-                .subject(name)
+                .subject(identifier)
                 .claim("scope", scope)
                 .build();
         return this.encoder.encode(JwtEncoderParameters.from(claims)).getTokenValue();


### PR DESCRIPTION
Refactor token generation to be based on the account id instead of the email / phone number.

- OwnerAccountManagerController - Applying formatting to the file.
- Account - Convert the DataType of id to long
- Refactor authenticationProvider services - Use the implmentation of userDetails like - CoachDetails - ClientDetails - OwnerDetails
- Refactor JpaCoachDetailsService & JpaOwnerDetailsService - Use the implmentation of userDetails
- Add get AcccountId to - CoachDetails - ClientDetails - OwnerDetails
- TokenService - Refactor generateToken method - token generation based on the account id instead of the email / phone number